### PR TITLE
fix(ui): ダークモード時のランチスクリーン背景とオンボーディング表示を修正

### DIFF
--- a/SerendipityPlanner/Info.plist
+++ b/SerendipityPlanner/Info.plist
@@ -27,10 +27,14 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIImageName</key>
 		<string>AppIconImage</string>
+		<key>UIColorName</key>
+		<string>LaunchScreenBackground</string>
 	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/SerendipityPlanner/Resources/Assets.xcassets/LaunchScreenBackground.colorset/Contents.json
+++ b/SerendipityPlanner/Resources/Assets.xcassets/LaunchScreenBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Summary
- `UIUserInterfaceStyle: Light` を Info.plist に追加し、アプリ全体を常にライトモードで表示
- ランチスクリーンに白背景カラーアセット (`LaunchScreenBackground`) を追加し、ダークモード端末でも黒背景にならないように修正

## Test plan
- [x] ダークモード設定の端末でアプリを起動し、ランチスクリーンが白背景で表示されることを確認
- [x] ダークモードでオンボーディングのジャンル選択ボタンが正しく表示されることを確認
- [x] ライトモードで既存の表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)