### PR TITLE
chore: v1.0.1リリース準備

### DIFF
--- a/SerendipityPlanner/Info.plist
+++ b/SerendipityPlanner/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/SerendipityPlanner/Views/Settings/SettingsView.swift
+++ b/SerendipityPlanner/Views/Settings/SettingsView.swift
@@ -207,8 +207,20 @@ struct SettingsView: View {
                         HStack {
                             Text("バージョン")
                             Spacer()
-                            Text("1.0.0")
+                            Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")
                                 .foregroundColor(.secondary)
+                        }
+
+                        if let url = URL(string: "https://ken-miyamura.github.io/serendipity-planner/privacy-policy.html") {
+                            Link(destination: url) {
+                                HStack {
+                                    Text("プライバシーポリシー")
+                                    Spacer()
+                                    Image(systemName: "arrow.up.right.square")
+                                        .font(.footnote)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
                         }
                     }
                 }

--- a/SerendipityWidget/Info.plist
+++ b/SerendipityWidget/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Summary
- バージョンを `1.0.1`、ビルド番号を `2` に更新（アプリ本体 + ウィジェット）
- 設定画面のバージョン表示をハードコードから `Bundle.main` による動的取得に変更
- 設定画面にプライバシーポリシーへの外部リンクを追加

## Test plan
- [x] 設定画面でバージョンが `1.0.1` と表示されることを確認
- [x] プライバシーポリシーリンクをタップしてブラウザで開くことを確認
- [x] Archiveでバージョン `1.0.1 (2)` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)