### PR TITLE
feat(map): マップアプリ選択ポップアップとプレビュータップ対応 (#21)

### DIFF
--- a/SerendipityPlanner.xcodeproj/project.pbxproj
+++ b/SerendipityPlanner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -73,6 +73,7 @@
 		D419755C84372DF136EC4AF1 /* FreeTimeSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDC697F7D1CC2A015688AFD /* FreeTimeSlot.swift */; };
 		D58896B93CFB15D1E9BA851D /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16A0511F69FBDFC73C6737A /* SettingsView.swift */; };
 		DBCE629254062E904F1D8B8F /* NotificationPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA6D3C2E9245C148F722344 /* NotificationPermissionView.swift */; };
+		DC94849253D332D97D9984F9 /* MapLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE509E42A58BEE2BFAB37E4 /* MapLauncher.swift */; };
 		DE13F1593BAD55652FDE1E62 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE11351A68EBF1F964AF811 /* View+Extensions.swift */; };
 		DE19BB03D86E06A902BCD44A /* PreferenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697B49FCA2B8F1128844A837 /* PreferenceService.swift */; };
 		E24F6A2C3C66C4BD48A37F64 /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609307DB67F6379A350559D2 /* SharedDataManager.swift */; };
@@ -163,24 +164,25 @@
 		6ACBEBF54FEC9855FC1880BA /* SmallWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallWidgetView.swift; sourceTree = "<group>"; };
 		6BD7DE95BFB179B989D3312C /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		6C8F929290B9669DF29514C2 /* CalendarServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarServiceTests.swift; sourceTree = "<group>"; };
-		6D0885B965AAB25D50153287 /* SerendipityPlanner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SerendipityPlanner.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D0885B965AAB25D50153287 /* SerendipityPlanner.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SerendipityPlanner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		72DE36CC96E5496700B5682C /* SuggestionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionDetailView.swift; sourceTree = "<group>"; };
 		73B7E797C0E05B67FFFBD25A /* HistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryService.swift; sourceTree = "<group>"; };
-		7F590A1A44D4AADA2284F5EE /* SerendipityPlannerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SerendipityPlannerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F590A1A44D4AADA2284F5EE /* SerendipityPlannerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SerendipityPlannerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8250300D5D448B02A23C40BA /* SerendipityPlannerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerendipityPlannerApp.swift; sourceTree = "<group>"; };
 		8596A4778BF1DFFAF21B47FD /* HistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRowView.swift; sourceTree = "<group>"; };
 		90F676FF5132C73780089608 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		97FFC658A07AA2B723C0E939 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		99AC8361221A1FE7C4E71EF7 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		99AC8361221A1FE7C4E71EF7 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A9DC8A9720C728B668EEED02 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		AAE305482EEDDC6FB248B2E2 /* WeatherData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherData.swift; sourceTree = "<group>"; };
 		AC433B0BF0B7BE25FF71E2DC /* AcceptedCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptedCardView.swift; sourceTree = "<group>"; };
 		AFE11351A68EBF1F964AF811 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		B0CB2D9D21D61067327AECD2 /* CalendarPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPermissionView.swift; sourceTree = "<group>"; };
 		B16A0511F69FBDFC73C6737A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		B610B05F0E027009888904AA /* SerendipityWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SerendipityWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		B610B05F0E027009888904AA /* SerendipityWidgetExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SerendipityWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB7DFFF0CEE6CAFECDF41BA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		BB9FFE965938FB56781BAFDE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		BCE509E42A58BEE2BFAB37E4 /* MapLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLauncher.swift; sourceTree = "<group>"; };
 		C0FA3418CA303C5680FB2729 /* SuggestionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineTests.swift; sourceTree = "<group>"; };
 		C269046CF438FECA1EA49D09 /* SerendipityWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SerendipityWidget.entitlements; sourceTree = "<group>"; };
 		C44FE781E50A4CCC7559AB5B /* Suggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Suggestion.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 			isa = PBXGroup;
 			children = (
 				F70280DCC1DC31D5097204BF /* Constants.swift */,
+				BCE509E42A58BEE2BFAB37E4 /* MapLauncher.swift */,
 				E34AAE88A4551A4AB83C3062 /* SuggestionTemplates.swift */,
 				F115EF680B296BADE0D1BAF5 /* Extensions */,
 			);
@@ -555,6 +558,7 @@
 			);
 			mainGroup = 985E2E6BB90E08DCE3BD9EF6;
 			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -626,6 +630,7 @@
 				8B9580E52EB01DBF0DC4EF16 /* InterestSelectionView.swift in Sources */,
 				6EA7680B637F1A5E4FFCD5B5 /* LocationInputView.swift in Sources */,
 				5D6CE2D8B3C102F6ACBF98C8 /* LocationService.swift in Sources */,
+				DC94849253D332D97D9984F9 /* MapLauncher.swift in Sources */,
 				DBCE629254062E904F1D8B8F /* NotificationPermissionView.swift in Sources */,
 				35D48B406A9E8B61BEB2170F /* NotificationService.swift in Sources */,
 				8052AD605F66A947D70EB24E /* NotificationSettingsView.swift in Sources */,
@@ -700,7 +705,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = BVQRL978G2;
 				INFOPLIST_FILE = SerendipityPlanner/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -778,11 +782,7 @@
 				CODE_SIGN_ENTITLEMENTS = SerendipityWidget/SerendipityWidget.entitlements;
 				DEVELOPMENT_TEAM = BVQRL978G2;
 				INFOPLIST_FILE = SerendipityWidget/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.serendipity.planner.widget;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -797,11 +797,7 @@
 				CODE_SIGN_ENTITLEMENTS = SerendipityWidget/SerendipityWidget.entitlements;
 				DEVELOPMENT_TEAM = BVQRL978G2;
 				INFOPLIST_FILE = SerendipityWidget/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.serendipity.planner.widget;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -832,7 +828,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = BVQRL978G2;
 				INFOPLIST_FILE = SerendipityPlanner/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SerendipityPlanner/Info.plist
+++ b/SerendipityPlanner/Info.plist
@@ -55,5 +55,9 @@
 	<string>現在地の近くにあるカフェや公園などを提案するために使用します。</string>
 	<key>OpenWeatherMapAPIKey</key>
 	<string>$(OPENWEATHERMAP_API_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>comgooglemaps</string>
+	</array>
 </dict>
 </plist>

--- a/SerendipityPlanner/Utilities/MapLauncher.swift
+++ b/SerendipityPlanner/Utilities/MapLauncher.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MapKit
+import UIKit
+
+enum MapApp: String, Identifiable, CaseIterable {
+    case appleMaps
+    case googleMaps
+    case browser
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .appleMaps: "Apple マップ"
+        case .googleMaps: "Google マップ"
+        case .browser: "ブラウザで開く"
+        }
+    }
+}
+
+enum MapLauncher {
+    static func availableApps() -> [MapApp] {
+        var apps: [MapApp] = [.appleMaps]
+        if let url = URL(string: "comgooglemaps://"),
+           UIApplication.shared.canOpenURL(url) {
+            apps.append(.googleMaps)
+        }
+        apps.append(.browser)
+        return apps
+    }
+
+    static func open(_ app: MapApp, name: String, latitude: Double, longitude: Double) {
+        switch app {
+        case .appleMaps:
+            let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+            let item = MKMapItem(placemark: MKPlacemark(coordinate: coordinate))
+            item.name = name
+            item.openInMaps(launchOptions: [
+                MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
+            ])
+        case .googleMaps:
+            let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            if let url = URL(string: "comgooglemaps://?q=\(encoded)&center=\(latitude),\(longitude)&zoom=16&directionsmode=walking") {
+                UIApplication.shared.open(url)
+            }
+        case .browser:
+            if let url = URL(string: "https://www.google.com/maps/search/?api=1&query=\(latitude),\(longitude)") {
+                UIApplication.shared.open(url)
+            }
+        }
+    }
+}

--- a/SerendipityPlanner/Utilities/MapLauncher.swift
+++ b/SerendipityPlanner/Utilities/MapLauncher.swift
@@ -41,8 +41,7 @@ enum MapLauncher {
                 MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
             ])
         case .googleMaps:
-            let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-            if let url = URL(string: "comgooglemaps://?q=\(encoded)&center=\(latitude),\(longitude)&zoom=16&directionsmode=walking") {
+            if let url = URL(string: "comgooglemaps://?q=\(latitude),\(longitude)&zoom=16") {
                 UIApplication.shared.open(url)
             }
         case .browser:

--- a/SerendipityPlanner/Views/Favorites/FavoriteDetailView.swift
+++ b/SerendipityPlanner/Views/Favorites/FavoriteDetailView.swift
@@ -7,6 +7,14 @@ struct FavoriteDetailView: View {
     let onDelete: () -> Void
 
     @State private var showDeleteConfirmation = false
+    @State private var showMapAppPicker = false
+    @State private var pendingMapTarget: PendingMapTarget?
+
+    private struct PendingMapTarget: Equatable {
+        let name: String
+        let latitude: Double
+        let longitude: Double
+    }
 
     var body: some View {
         ScrollView {
@@ -44,6 +52,25 @@ struct FavoriteDetailView: View {
             Button("キャンセル", role: .cancel) {}
         } message: {
             Text("このお気に入りを削除しますか？")
+        }
+        .confirmationDialog(
+            "マップアプリで開く",
+            isPresented: $showMapAppPicker,
+            titleVisibility: .visible
+        ) {
+            if let target = pendingMapTarget {
+                ForEach(MapLauncher.availableApps()) { app in
+                    Button(app.displayName) {
+                        MapLauncher.open(
+                            app,
+                            name: target.name,
+                            latitude: target.latitude,
+                            longitude: target.longitude
+                        )
+                    }
+                }
+                Button("キャンセル", role: .cancel) {}
+            }
         }
     }
 
@@ -108,7 +135,7 @@ struct FavoriteDetailView: View {
                     Spacer()
                     if let lat = favorite.latitude, let lon = favorite.longitude {
                         Button {
-                            openInMaps(name: placeName, latitude: lat, longitude: lon)
+                            presentMapPicker(name: placeName, latitude: lat, longitude: lon)
                         } label: {
                             Image(systemName: "map.fill")
                                 .font(.body)
@@ -129,13 +156,42 @@ struct FavoriteDetailView: View {
     }
 
     private func mapSection(latitude: Double, longitude: Double) -> some View {
+        Button {
+            presentMapPicker(
+                name: favorite.placeName ?? favorite.title,
+                latitude: latitude,
+                longitude: longitude
+            )
+        } label: {
+            mapPreview(latitude: latitude, longitude: longitude)
+                .overlay(alignment: .topTrailing) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.up.right.square.fill")
+                        Text("マップで開く")
+                    }
+                    .font(.caption2)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.black.opacity(0.55))
+                    .clipShape(Capsule())
+                    .padding(8)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(favorite.placeName ?? favorite.title)をマップで開く")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func mapPreview(latitude: Double, longitude: Double) -> some View {
         let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
         let region = MKCoordinateRegion(
             center: coordinate,
             latitudinalMeters: 500,
             longitudinalMeters: 500
         )
-        // MapAnnotation 用のダミーデータ
         let annotations = [MapAnnotationItem(id: favorite.id, coordinate: coordinate)]
 
         return Map(coordinateRegion: .constant(region), annotationItems: annotations) { item in
@@ -160,7 +216,6 @@ struct FavoriteDetailView: View {
         .frame(height: 180)
         .cornerRadius(12)
         .allowsHitTesting(false)
-        .accessibilityHidden(true)
     }
 
     private var addedDateSection: some View {
@@ -203,14 +258,9 @@ struct FavoriteDetailView: View {
         return formatter.string(from: favorite.addedDate)
     }
 
-    private func openInMaps(name: String, latitude: Double, longitude: Double) {
-        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
-        let placemark = MKPlacemark(coordinate: coordinate)
-        let mapItem = MKMapItem(placemark: placemark)
-        mapItem.name = name
-        mapItem.openInMaps(launchOptions: [
-            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
-        ])
+    private func presentMapPicker(name: String, latitude: Double, longitude: Double) {
+        pendingMapTarget = PendingMapTarget(name: name, latitude: latitude, longitude: longitude)
+        showMapAppPicker = true
     }
 }
 

--- a/SerendipityPlanner/Views/Suggestion/SuggestionDetailView.swift
+++ b/SerendipityPlanner/Views/Suggestion/SuggestionDetailView.swift
@@ -6,6 +6,9 @@ struct SuggestionDetailView: View {
     let onAccept: () -> Void
     let onRegenerate: () -> Void
 
+    @State private var showMapAppPicker = false
+    @State private var pendingPlace: NearbyPlace?
+
     private let weather: WeatherData?
     private let preference: UserPreference
     private let preferenceService: PreferenceServiceProtocol?
@@ -103,6 +106,25 @@ struct SuggestionDetailView: View {
         ) {
             Button("OK", role: .cancel) {
                 onAccept()
+            }
+        }
+        .confirmationDialog(
+            "マップアプリで開く",
+            isPresented: $showMapAppPicker,
+            titleVisibility: .visible
+        ) {
+            if let place = pendingPlace {
+                ForEach(MapLauncher.availableApps()) { app in
+                    Button(app.displayName) {
+                        MapLauncher.open(
+                            app,
+                            name: place.name,
+                            latitude: place.latitude,
+                            longitude: place.longitude
+                        )
+                    }
+                }
+                Button("キャンセル", role: .cancel) {}
             }
         }
         .task {
@@ -220,7 +242,7 @@ struct SuggestionDetailView: View {
                     }
                     Spacer()
                     Button {
-                        openInMaps(place: place)
+                        presentMapPicker(for: place)
                     } label: {
                         Image(systemName: "map.fill")
                             .font(.body)
@@ -243,53 +265,30 @@ struct SuggestionDetailView: View {
     @ViewBuilder
     private var placeMapSection: some View {
         if let place = viewModel.suggestion.nearbyPlace {
-            let coordinate = CLLocationCoordinate2D(
-                latitude: place.latitude,
-                longitude: place.longitude
-            )
-            let region = MKCoordinateRegion(
-                center: coordinate,
-                latitudinalMeters: 500,
-                longitudinalMeters: 500
-            )
-
-            Map(coordinateRegion: .constant(region), annotationItems: [place]) { p in
-                MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: p.latitude, longitude: p.longitude)) {
-                    VStack(spacing: 2) {
-                        Image(systemName: viewModel.suggestion.category.iconName)
-                            .font(.caption)
-                            .foregroundColor(.white)
-                            .frame(width: 28, height: 28)
-                            .background(Color.theme.color(for: viewModel.suggestion.category))
-                            .clipShape(Circle())
-                            .shadow(radius: 2)
-
-                        Image(systemName: "triangle.fill")
-                            .font(.system(size: 6))
-                            .foregroundColor(Color.theme.color(for: viewModel.suggestion.category))
-                            .rotationEffect(.degrees(180))
-                            .offset(y: -4)
+            Button {
+                presentMapPicker(for: place)
+            } label: {
+                mapPreview(for: place)
+                    .overlay(alignment: .topTrailing) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.up.right.square.fill")
+                            Text("マップで開く")
+                        }
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.black.opacity(0.55))
+                        .clipShape(Capsule())
+                        .padding(8)
                     }
-                }
+                    .contentShape(Rectangle())
             }
-            .frame(height: 180)
-            .cornerRadius(12)
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-            .onTapGesture {
-                openInMaps(place: place)
-            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(place.name)をマップで開く")
+            .accessibilityAddTraits(.isButton)
         }
-    }
-
-    private func openInMaps(place: NearbyPlace) {
-        let coordinate = CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude)
-        let placemark = MKPlacemark(coordinate: coordinate)
-        let mapItem = MKMapItem(placemark: placemark)
-        mapItem.name = place.name
-        mapItem.openInMaps(launchOptions: [
-            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
-        ])
     }
 
     private var alternativesSection: some View {
@@ -304,6 +303,50 @@ struct SuggestionDetailView: View {
             onAccept: onAccept,
             onRegenerate: onRegenerate
         )
+    }
+}
+
+// MARK: - マップ関連ヘルパー
+
+private extension SuggestionDetailView {
+    func mapPreview(for place: NearbyPlace) -> some View {
+        let coordinate = CLLocationCoordinate2D(
+            latitude: place.latitude,
+            longitude: place.longitude
+        )
+        let region = MKCoordinateRegion(
+            center: coordinate,
+            latitudinalMeters: 500,
+            longitudinalMeters: 500
+        )
+
+        return Map(coordinateRegion: .constant(region), annotationItems: [place]) { p in
+            MapAnnotation(coordinate: CLLocationCoordinate2D(latitude: p.latitude, longitude: p.longitude)) {
+                VStack(spacing: 2) {
+                    Image(systemName: viewModel.suggestion.category.iconName)
+                        .font(.caption)
+                        .foregroundColor(.white)
+                        .frame(width: 28, height: 28)
+                        .background(Color.theme.color(for: viewModel.suggestion.category))
+                        .clipShape(Circle())
+                        .shadow(radius: 2)
+
+                    Image(systemName: "triangle.fill")
+                        .font(.system(size: 6))
+                        .foregroundColor(Color.theme.color(for: viewModel.suggestion.category))
+                        .rotationEffect(.degrees(180))
+                        .offset(y: -4)
+                }
+            }
+        }
+        .frame(height: 180)
+        .cornerRadius(12)
+        .allowsHitTesting(false)
+    }
+
+    func presentMapPicker(for place: NearbyPlace) {
+        pendingPlace = place
+        showMapAppPicker = true
     }
 }
 


### PR DESCRIPTION
## Summary

Issue #21 の対応。マップを開くときに Apple マップ / Google マップ / ブラウザ から毎回選べるようにし、プレビュー小マップ自体もタップ対象として明示しました。

- `MapLauncher` を新設して起動ロジックを共通化（旧 `openInMaps` を 2 ファイルから削除）
- `confirmationDialog` で毎回ユーザーが選択
  - Google マップ未インストール時は選択肢から除外
  - 「ブラウザで開く」は常に Google Maps Web にフォールバック
- 提案詳細・お気に入り詳細のプレビュー小マップを `Button` でラップし、右上に「マップで開く」ヒントを overlay
  - お気に入り詳細はこれまでプレビュー部分がタップ不可だったため操作経路を統一
- `Info.plist` に `LSApplicationQueriesSchemes` (`comgooglemaps`) を追加して `canOpenURL` 判定を有効化

## Test plan

- [x] 提案詳細を開いてマップボタンをタップ → confirmationDialog が出る
- [x] 提案詳細のプレビュー小マップをタップ → confirmationDialog が出る／右上にヒント表示
- [x] お気に入り詳細のマップボタンをタップ → confirmationDialog が出る
- [x] お気に入り詳細のプレビュー小マップをタップ → confirmationDialog が出る／右上にヒント表示
- [x] 「Apple マップ」選択 → Apple マップが歩行ルート付きで起動
- [x] 「ブラウザで開く」選択 → Safari で Google Maps Web が開く
- [x] Google マップアプリがインストールされた実機で 3 つ目の選択肢「Google マップ」が表示され、選択するとアプリが起動
- [x] シミュレーター（Google マップなし）で選択肢が「Apple マップ / ブラウザで開く」の 2 つになる
- [x] 既存テスト (`SerendipityPlannerTests`) が通る

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)