### PR TITLE
fix(map): マップアプリ選択シートが白紙で表示される問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,32 @@
   xcrun simctl launch "iPhone 17 Pro" com.serendipity.planner
   ```
 
+## 動作確認（必須）
+
+**起動確認で終わらせない。変更した画面まで実際に遷移し、変更した操作をタップして確かめる。**
+
+- シート・ダイアログ・ピッカーを変更したら、**開いた中身が表示されていること**をスクリーンショットで確認する。
+  「提示された」だけでは不十分 — 中身が空の白紙シートが出るバグを v2.0.0 でリリースした実績がある。
+- 画面遷移を変更したら、遷移先が描画されていることまで確認する。
+- 外部アプリ連携（マップ等）を変更したら、連携先が起動するところまで確認する。
+- **確認できていない項目は「未確認」と正直に報告する。** 推測で「動くはず」と書かない。
+
+### シミュレーターの操作方法
+
+タップは Simulator のアクセシビリティ経由で自動化できる（論理座標 402x874 pt で指定）:
+
+```sh
+PX=200; PY=417   # タップしたい論理座標
+POS=$(osascript -e 'tell application "System Events" to tell process "Simulator" to get position of window 1')
+SIZ=$(osascript -e 'tell application "System Events" to tell process "Simulator" to get size of window 1')
+WX=${POS%%,*}; WY=${POS##*, }; WW=${SIZ%%,*}; WH=${SIZ##*, }
+SX=$(echo "$WX + $PX * $WW / 402" | bc -l); SY=$(echo "$WY + $PY * $WH / 874" | bc -l)
+osascript -e 'tell application "Simulator" to activate' -e "tell application \"System Events\" to click at {${SX%.*}, ${SY%.*}}"
+```
+
+スクリーンショット: `xcrun simctl io "iPhone 17 Pro" screenshot out.png`
+（スクショの表示座標 → 論理座標は `論理 = 表示 * 402 / 表示画像の幅`）
+
 ## Project Structure
 
 - iOS app (SwiftUI)

--- a/SerendipityPlanner/Views/Favorites/FavoriteDetailView.swift
+++ b/SerendipityPlanner/Views/Favorites/FavoriteDetailView.swift
@@ -7,10 +7,12 @@ struct FavoriteDetailView: View, SkyTextStyling {
     let onDelete: () -> Void
 
     @State private var showDeleteConfirmation = false
-    @State private var showMapAppPicker = false
+    /// マップアプリ選択シートの対象。`sheet(item:)` で提示するため、
+    /// `isPresented` + `if let` の組み合わせ（内容が空のまま提示され白紙シートになる）を避ける。
     @State private var pendingMapTarget: PendingMapTarget?
 
-    private struct PendingMapTarget: Equatable {
+    private struct PendingMapTarget: Identifiable, Equatable {
+        let id = UUID()
         let name: String
         let latitude: Double
         let longitude: Double
@@ -54,14 +56,12 @@ struct FavoriteDetailView: View, SkyTextStyling {
         } message: {
             Text("このお気に入りを削除しますか？")
         }
-        .sheet(isPresented: $showMapAppPicker) {
-            if let target = pendingMapTarget {
-                MapAppPickerSheet(
-                    placeName: target.name,
-                    latitude: target.latitude,
-                    longitude: target.longitude
-                )
-            }
+        .sheet(item: $pendingMapTarget) { target in
+            MapAppPickerSheet(
+                placeName: target.name,
+                latitude: target.latitude,
+                longitude: target.longitude
+            )
         }
     }
 
@@ -253,7 +253,6 @@ struct FavoriteDetailView: View, SkyTextStyling {
 
     private func presentMapPicker(name: String, latitude: Double, longitude: Double) {
         pendingMapTarget = PendingMapTarget(name: name, latitude: latitude, longitude: longitude)
-        showMapAppPicker = true
     }
 }
 

--- a/SerendipityPlanner/Views/Suggestion/SuggestionDetailView.swift
+++ b/SerendipityPlanner/Views/Suggestion/SuggestionDetailView.swift
@@ -9,7 +9,8 @@ struct SuggestionDetailView: View, SkyTextStyling {
     /// 再生成後の新しい提案を親へ渡す（ホーム側のリストを同じ提案で置き換えるため）。
     let onRegenerate: (Suggestion) -> Void
 
-    @State private var showMapAppPicker = false
+    /// マップアプリ選択シートの対象。`sheet(item:)` で提示するため、
+    /// `isPresented` + `if let` の組み合わせ（内容が空のまま提示され白紙シートになる）を避ける。
     @State private var pendingPlace: NearbyPlace?
 
     private let weather: WeatherData?
@@ -124,14 +125,12 @@ struct SuggestionDetailView: View, SkyTextStyling {
                 onAccept(viewModel.suggestion)
             }
         }
-        .sheet(isPresented: $showMapAppPicker) {
-            if let place = pendingPlace {
-                MapAppPickerSheet(
-                    placeName: place.name,
-                    latitude: place.latitude,
-                    longitude: place.longitude
-                )
-            }
+        .sheet(item: $pendingPlace) { place in
+            MapAppPickerSheet(
+                placeName: place.name,
+                latitude: place.latitude,
+                longitude: place.longitude
+            )
         }
         .task {
             await viewModel.enrichIfNeeded()
@@ -402,6 +401,5 @@ private extension SuggestionDetailView {
 
     func presentMapPicker(for place: NearbyPlace) {
         pendingPlace = place
-        showMapAppPicker = true
     }
 }


### PR DESCRIPTION
## 概要

v2.0.0 で、提案詳細・お気に入り詳細のマップをタップすると**中身が空のシートがフルハイトで表示され、マップアプリに遷移できない**バグが発生していました。シミュレーターで再現を確認し、修正しています。

## 原因

sheet の提示トリガーと中身を別々の `@State` で持っていたことが原因です。

```swift
@State private var showMapAppPicker = false   // 出すか？
@State private var pendingPlace: NearbyPlace? // 何を出す？

.sheet(isPresented: $showMapAppPicker) {
    if let place = pendingPlace { MapAppPickerSheet(...) }
}
```

`.sheet(isPresented:)` の content クロージャはキャプチャした View 値から `@State` を読むため、`pendingPlace` が `nil` のまま評価され、中身が `EmptyView` になっていました。中身がゼロなので `MapAppPickerSheet` 側の `presentationDetents` も適用されず、結果としてフルハイトの白紙シートに。

2つの変数で4通りの状態が表現でき、そのうち `(true, nil)` =「出すけど中身が無い」という不正状態に落ちていた、という構造です。

## 混入時期

`b47513a` `fix(map): マップアプリ選択を下から出るボトムシートに修正` (2026-07-09)。

置き換え前の `confirmationDialog` はボタンを `MapLauncher.availableApps()` から直接組み立てており `pendingPlace` に依存していなかったため、この問題は起きていませんでした。popover 表示の修正時に提示トリガーと中身が別 State に分かれ、混入しています。

## 変更内容

- 両画面の sheet を `.sheet(item:)` に変更。提示トリガーと中身を1つの値に統合し、不正な状態を表現できなくした
- 不要になった `showMapAppPicker` フラグを削除
- `FavoriteDetailView` の `PendingMapTarget` を `Identifiable` に準拠
- CLAUDE.md の動作確認ルールを具体化（後述）

同じパターンが他に残っていないか `.sheet(isPresented:)` / `.fullScreenCover(isPresented:)` を全走査しましたが、該当はありませんでした。

## 再発防止

本件は100%再現・初回タップ・主要動線のバグで、1回タップすれば気づくものでした。それがリリースまで通ったのは、CLAUDE.md のルールが「起動して確認」で止まっており、**変更した動線を踏むところまで求めていなかった**ためです。

そこで CLAUDE.md に「動作確認（必須）」セクションを追加し、以下を明文化しました。

- 変更した画面まで遷移して、変更した操作をタップする
- シート・ダイアログは**開いた中身が表示されていること**をスクショで確認する
- 確認できていない項目は「未確認」と正直に報告する
- あわせて、シミュレーターのタップを自動化する手順を記載

## 動作確認

シミュレーター (iPhone 17 Pro / iOS 26.2) で確認済み:

1. 提案詳細のマップをタップ → ピッカーが正しい高さのボトムシートで表示
2. 「Apple マップ」をタップ → マップ.app が起動し、目的地への徒歩経路が表示

`swiftformat --lint` / `swiftlint --strict` ともにクリーンです。

## 補足

バージョン番号は据え置きです。2.0.1 として出す場合は別途 bump が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)