### PR TITLE
fix(destination): 地名表記が端末の言語と混在する問題にフォールバックを入れる

### DIFF
--- a/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
+++ b/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Apple のジオデータに含まれる地名テキストを表示してよいか判定する。
+///
+/// ## 背景
+///
+/// MapKit は端末の言語設定に従って地名を返すが、**すべての記録に全言語のデータが
+/// 揃っているわけではない**。日本語端末でも一部の記録は英語のまま返る。
+///
+/// ```
+/// 東京タワー → 東京都 港区        ← ja データあり
+/// 皇居外苑   → Tokyo Chiyoda-Ku   ← ja データが無く英語で返る
+/// ```
+///
+/// 一覧の中で1件だけ表記体系が変わると異物として目立つため、端末の言語と表記が
+/// 一致しないものは表示から落とす。距離表示は必ず出るので、落としても情報が
+/// ゼロになることはない。
+///
+/// ## 「ASCII が含まれていたら落とす」ではない
+///
+/// ロケール非依存に「英字が含まれていたら落とす」ルールにすると、英語端末で
+/// 正しく英語が返っているケースまで全部消えてしまう。データ欠損は**どの言語でも**
+/// 起きるため、判定は必ず端末の言語を基準に行う。
+enum PlacemarkTextFilter {
+    /// 主にラテン文字で表記する言語。これ以外は固有の文字体系を持つ扱いにする。
+    private static let latinScriptLanguages: Set<String> = [
+        "en", "es", "fr", "de", "it", "pt", "nl", "sv", "da", "no", "fi",
+        "pl", "cs", "tr", "id", "vi", "ms", "ro", "hu", "hr", "sk", "sl",
+    ]
+
+    /// 端末の言語と表記体系が一致しているか。
+    ///
+    /// - ラテン文字の言語（en / es / fr など）: 非ラテン文字が混ざっていたら不一致
+    /// - 固有文字体系の言語（ja / ko など）: ラテン文字だけで構成されていたら不一致
+    ///
+    /// 数字・記号・空白は判定に使わない（「1丁目」「Chiyoda-Ku」のような
+    /// 混在表記を誤判定しないため）。
+    static func matchesDeviceLanguage(
+        _ text: String,
+        languageCode: String = Locale.currentLanguageCode
+    ) -> Bool {
+        let letters = text.unicodeScalars.filter { CharacterSet.letters.contains($0) }
+        // 判定材料が無い（数字と記号だけ等）ものは落とさない
+        guard !letters.isEmpty else { return true }
+
+        let hasNonLatin = letters.contains { !isLatin($0) }
+
+        if latinScriptLanguages.contains(languageCode) {
+            return !hasNonLatin
+        }
+        return hasNonLatin
+    }
+
+    /// 表示してよければそのまま返し、表記が一致しなければ nil を返す
+    static func displayable(
+        _ text: String?,
+        languageCode: String = Locale.currentLanguageCode
+    ) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        return matchesDeviceLanguage(text, languageCode: languageCode) ? text : nil
+    }
+
+    private static func isLatin(_ scalar: Unicode.Scalar) -> Bool {
+        // 基本ラテン + ラテン拡張（アクセント付き文字を含む）
+        switch scalar.value {
+        case 0x0041 ... 0x005A, 0x0061 ... 0x007A, 0x00C0 ... 0x024F:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
+++ b/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
@@ -25,7 +25,7 @@ enum PlacemarkTextFilter {
     /// 主にラテン文字で表記する言語。これ以外は固有の文字体系を持つ扱いにする。
     private static let latinScriptLanguages: Set<String> = [
         "en", "es", "fr", "de", "it", "pt", "nl", "sv", "da", "no", "fi",
-        "pl", "cs", "tr", "id", "vi", "ms", "ro", "hu", "hr", "sk", "sl",
+        "pl", "cs", "tr", "id", "vi", "ms", "ro", "hu", "hr", "sk", "sl"
     ]
 
     /// 端末の言語と表記体系が一致しているか。

--- a/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
+++ b/SerendipityPlanner/Utilities/PlacemarkTextFilter.swift
@@ -2,62 +2,70 @@ import Foundation
 
 /// Apple のジオデータに含まれる地名テキストを表示してよいか判定する。
 ///
-/// ## 背景
+/// ## 何を解こうとしているか
 ///
-/// MapKit は端末の言語設定に従って地名を返すが、**すべての記録に全言語のデータが
-/// 揃っているわけではない**。日本語端末でも一部の記録は英語のまま返る。
+/// MapKit は端末の言語設定に従って地名を返す。これ自体は正しい挙動で、日本語設定のまま
+/// パリへ行けばラテン文字の地名が返るのが期待どおり（Apple マップと同じ）。
+///
+/// 問題は **Apple 側のデータ欠損**のほう。日本国内では ja データが揃っているのに一部の記録
+/// だけ欠けていて、同じ一覧の中で1件だけ表記が変わる。
 ///
 /// ```
-/// 東京タワー → 東京都 港区        ← ja データあり
-/// 皇居外苑   → Tokyo Chiyoda-Ku   ← ja データが無く英語で返る
+/// 和田倉噴水公園 / 東京都・現在地から約612 m
+/// 将門塚        / 東京都・現在地から約783 m
+/// 皇居外苑      / Tokyo・現在地から約854 m   ← ここだけ浮く
 /// ```
 ///
-/// 一覧の中で1件だけ表記体系が変わると異物として目立つため、端末の言語と表記が
-/// 一致しないものは表示から落とす。距離表示は必ず出るので、落としても情報が
-/// ゼロになることはない。
+/// ## 端末の言語ではなく「一覧の多数派」で判定する
 ///
-/// ## 「ASCII が含まれていたら落とす」ではない
+/// 「端末の言語と表記体系が合わないものを落とす」という**絶対判定にしてはいけない**。
+/// パリでは ja データがほぼ存在しないため全件がラテン文字になり、絶対判定だと地域名が
+/// 全滅する（実測で6件すべてが距離のみになった）。海外でラテン文字が出るのは正常なので、
+/// これは過剰な除去。
 ///
-/// ロケール非依存に「英字が含まれていたら落とす」ルールにすると、英語端末で
-/// 正しく英語が返っているケースまで全部消えてしまう。データ欠損は**どの言語でも**
-/// 起きるため、判定は必ず端末の言語を基準に行う。
+/// そこで**その一覧の多数派の表記体系**を基準にし、そこから外れた行だけ落とす。
+///
+/// - 東京: 多数派が日本語 → "Tokyo" の1件だけ落ちる
+/// - パリ: 多数派がラテン文字 → 全件そのまま残る
+///
+/// 「英字が含まれていたら落とす」というロケール非依存のルールも同じ理由で不可。
 enum PlacemarkTextFilter {
-    /// 主にラテン文字で表記する言語。これ以外は固有の文字体系を持つ扱いにする。
-    private static let latinScriptLanguages: Set<String> = [
-        "en", "es", "fr", "de", "it", "pt", "nl", "sv", "da", "no", "fi",
-        "pl", "cs", "tr", "id", "vi", "ms", "ro", "hu", "hr", "sk", "sl"
-    ]
-
-    /// 端末の言語と表記体系が一致しているか。
-    ///
-    /// - ラテン文字の言語（en / es / fr など）: 非ラテン文字が混ざっていたら不一致
-    /// - 固有文字体系の言語（ja / ko など）: ラテン文字だけで構成されていたら不一致
-    ///
-    /// 数字・記号・空白は判定に使わない（「1丁目」「Chiyoda-Ku」のような
-    /// 混在表記を誤判定しないため）。
-    static func matchesDeviceLanguage(
-        _ text: String,
-        languageCode: String = Locale.currentLanguageCode
-    ) -> Bool {
-        let letters = text.unicodeScalars.filter { CharacterSet.letters.contains($0) }
-        // 判定材料が無い（数字と記号だけ等）ものは落とさない
-        guard !letters.isEmpty else { return true }
-
-        let hasNonLatin = letters.contains { !isLatin($0) }
-
-        if latinScriptLanguages.contains(languageCode) {
-            return !hasNonLatin
-        }
-        return hasNonLatin
+    /// 地名テキストの表記体系
+    enum Script {
+        /// ラテン文字（英語・スペイン語・フランス語など）
+        case latin
+        /// ラテン文字以外（日本語・韓国語など）
+        case nonLatin
     }
 
-    /// 表示してよければそのまま返し、表記が一致しなければ nil を返す
-    static func displayable(
-        _ text: String?,
-        languageCode: String = Locale.currentLanguageCode
-    ) -> String? {
-        guard let text, !text.isEmpty else { return nil }
-        return matchesDeviceLanguage(text, languageCode: languageCode) ? text : nil
+    /// テキストの表記体系。判定材料（文字）が無ければ nil。
+    ///
+    /// 数字・記号・空白は判定に使わない。「1丁目」「Chiyoda-Ku」のような混在表記を
+    /// 誤判定しないため、**文字が1つでも非ラテンなら非ラテン**として扱う。
+    static func script(of text: String) -> Script? {
+        let letters = text.unicodeScalars.filter { CharacterSet.letters.contains($0) }
+        guard !letters.isEmpty else { return nil }
+        return letters.contains { !isLatin($0) } ? .nonLatin : .latin
+    }
+
+    /// 一覧の中で多数派の表記体系。判定できない場合や同数の場合は nil を返す。
+    ///
+    /// nil のときは何も落とさない。基準が決まらない状態で落とすと、情報を減らすだけになるため。
+    static func dominantScript(in texts: [String]) -> Script? {
+        let scripts = texts.compactMap(script(of:))
+        guard !scripts.isEmpty else { return nil }
+
+        let latin = scripts.filter { $0 == .latin }.count
+        let nonLatin = scripts.count - latin
+        if latin == nonLatin { return nil }
+        return latin > nonLatin ? .latin : .nonLatin
+    }
+
+    /// 多数派に沿っていれば表示してよい。
+    /// 基準が無い（`dominant` が nil）場合や判定材料が無い場合は落とさない。
+    static func isDisplayable(_ text: String, dominant: Script?) -> Bool {
+        guard let dominant, let script = script(of: text) else { return true }
+        return script == dominant
     }
 
     private static func isLatin(_ scalar: Unicode.Scalar) -> Bool {

--- a/SerendipityPlanner/ViewModels/DestinationSearchViewModel.swift
+++ b/SerendipityPlanner/ViewModels/DestinationSearchViewModel.swift
@@ -194,9 +194,14 @@ final class DestinationSearchViewModel: ObservableObject {
         let distance = userLocation.distance(
             from: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
         )
-        let region = placemark.administrativeArea ?? placemark.locality ?? ""
+        // Apple のジオデータには言語ごとの欠損があり、日本語端末でも一部の記録は
+        // 英語のまま返る（例: 丸の内で皇居外苑だけ "Tokyo"）。一覧の中で1件だけ
+        // 表記が変わると異物として目立つため、端末の言語と合わないものは落とす。
+        // 距離は必ず出るので、落としても情報がゼロにはならない。
+        let region = PlacemarkTextFilter.displayable(placemark.administrativeArea)
+            ?? PlacemarkTextFilter.displayable(placemark.locality)
         let distanceText = Self.distanceText(meters: distance)
-        let subtitle = region.isEmpty ? distanceText : "\(region)・\(distanceText)"
+        let subtitle = region.map { String(localized: "\($0)・\(distanceText)") } ?? distanceText
 
         return TodayDestination(
             name: name,

--- a/SerendipityPlanner/ViewModels/DestinationSearchViewModel.swift
+++ b/SerendipityPlanner/ViewModels/DestinationSearchViewModel.swift
@@ -144,7 +144,7 @@ final class DestinationSearchViewModel: ObservableObject {
             span: MKCoordinateSpan(latitudeDelta: 0.45, longitudeDelta: 0.45)
         )
 
-        var collected: [TodayDestination] = []
+        var collected: [RecommendationCandidate] = []
         var seenNames = Set<String>()
 
         for query in RecommendationQueries.current {
@@ -154,18 +154,19 @@ final class DestinationSearchViewModel: ObservableObject {
             guard let response = try? await MKLocalSearch(request: request).start() else { continue }
 
             for item in response.mapItems {
-                guard let destination = Self.recommendedDestination(from: item, userLocation: location),
-                      seenNames.insert(destination.name).inserted else { continue }
-                collected.append(destination)
+                guard let candidate = RecommendationCandidate(item: item, userLocation: location),
+                      seenNames.insert(candidate.name).inserted else { continue }
+                collected.append(candidate)
             }
         }
 
         // 現在地から近い順に並べ、上限件数で打ち切る
-        recommendedAreas = Array(
-            collected
-                .sorted { location.distance(from: $0.location) < location.distance(from: $1.location) }
-                .prefix(maxRecommendations)
-        )
+        let shown = collected.sorted { $0.distance < $1.distance }.prefix(maxRecommendations)
+
+        // 表示する行の中での多数派の表記体系を基準にする。
+        // 端末の言語を基準にすると、ja データがほぼ無い海外で地域名が全滅してしまう。
+        let dominant = PlacemarkTextFilter.dominantScript(in: shown.compactMap(\.regionText))
+        recommendedAreas = shown.map { $0.destination(dominantScript: dominant) }
     }
 
     /// 候補列挙のバイアス基点。現在地があれば現在地を中心に広めにバイアスし、
@@ -183,37 +184,46 @@ final class DestinationSearchViewModel: ObservableObject {
 
     // MARK: - 変換
 
-    /// おすすめエリアの MKMapItem を今日の目的地へ変換する（現在地からの距離を補足に含める）
-    private static func recommendedDestination(
-        from item: MKMapItem,
-        userLocation: CLLocation
-    ) -> TodayDestination? {
-        guard let name = item.name else { return nil }
-        let placemark = item.placemark
-        let coordinate = placemark.coordinate
-        let distance = userLocation.distance(
-            from: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
-        )
-        // Apple のジオデータには言語ごとの欠損があり、日本語端末でも一部の記録は
-        // 英語のまま返る（例: 丸の内で皇居外苑だけ "Tokyo"）。一覧の中で1件だけ
-        // 表記が変わると異物として目立つため、端末の言語と合わないものは落とす。
-        // 距離は必ず出るので、落としても情報がゼロにはならない。
-        let region = PlacemarkTextFilter.displayable(placemark.administrativeArea)
-            ?? PlacemarkTextFilter.displayable(placemark.locality)
-        let distanceText = Self.distanceText(meters: distance)
-        let subtitle = region.map { String(localized: "\($0)・\(distanceText)") } ?? distanceText
+    /// おすすめエリアの中間表現。
+    ///
+    /// 地域名を出すかどうかは**一覧全体を見ないと決められない**ため、subtitle の組み立てを
+    /// 後回しにして素材だけ持つ。1件ずつ確定させると多数派が判定できない。
+    private struct RecommendationCandidate {
+        let name: String
+        /// 地名テキスト（未取得なら nil）。表示するかは後で決める。
+        let regionText: String?
+        let coordinate: CLLocationCoordinate2D
+        let distance: CLLocationDistance
 
-        return TodayDestination(
-            name: name,
-            subtitle: subtitle,
-            latitude: coordinate.latitude,
-            longitude: coordinate.longitude
-        )
+        init?(item: MKMapItem, userLocation: CLLocation) {
+            guard let name = item.name else { return nil }
+            let placemark = item.placemark
+            self.name = name
+            self.coordinate = placemark.coordinate
+            self.distance = userLocation.distance(
+                from: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            )
+            self.regionText = placemark.administrativeArea ?? placemark.locality
+        }
+
+        /// 多数派の表記体系を渡して目的地に変換する。
+        /// 多数派から外れた地域名は落として距離のみにする（距離は必ず出るので情報はゼロにならない）。
+        func destination(dominantScript: PlacemarkTextFilter.Script?) -> TodayDestination {
+            let distanceText = DestinationSearchViewModel.distanceText(meters: distance)
+            let region = regionText.flatMap {
+                PlacemarkTextFilter.isDisplayable($0, dominant: dominantScript) ? $0 : nil
+            }
+            return TodayDestination(
+                name: name,
+                subtitle: region.map { String(localized: "\($0)・\(distanceText)") } ?? distanceText,
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude
+            )
+        }
     }
 
-    /// 現在地からの距離。単位はロケールに従う（m/km または ft/mi）。
-    /// 「現在地から約」の文言自体は #32 で String Catalog に移す。
-    private static func distanceText(meters: Double) -> String {
+    /// 純粋な整形処理なので nonisolated（候補の変換から呼ぶため）
+    fileprivate nonisolated static func distanceText(meters: Double) -> String {
         String(localized: "現在地から約\(LocalizedUnits.distance(meters: meters))")
     }
 }

--- a/SerendipityPlannerTests/PlacemarkTextFilterTests.swift
+++ b/SerendipityPlannerTests/PlacemarkTextFilterTests.swift
@@ -2,73 +2,98 @@
 import XCTest
 
 /// #29: Apple のジオデータ欠損で subtitle の表記が混ざる問題のフォールバック。
+///
+/// 判定は「端末の言語」ではなく「その一覧の多数派」を基準にする。
+/// 端末言語で絶対判定すると、ja データがほぼ無い海外で地域名が全滅する。
 final class PlacemarkTextFilterTests: XCTestCase {
-    // MARK: - 日本語端末
+    // MARK: - 表記体系の判定
 
-    /// 日本語端末では日本語の地名をそのまま出すこと
-    func testJapaneseDeviceKeepsJapaneseText() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("東京都", languageCode: "ja"))
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("東京都 港区", languageCode: "ja"))
-        XCTAssertEqual(PlacemarkTextFilter.displayable("島根県", languageCode: "ja"), "島根県")
+    func testScriptDetection() {
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "東京都"), .nonLatin)
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "서울특별시"), .nonLatin)
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "Tokyo"), .latin)
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "Île-de-France"), .latin)
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "Málaga"), .latin)
     }
 
-    /// 日本語端末に英語データが返ってきたら落とすこと（#29 の報告事象）
-    func testJapaneseDeviceDropsEnglishText() {
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "ja"))
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo Chiyoda-Ku", languageCode: "ja"))
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Kyoto Kita-Ku, Kyoto", languageCode: "ja"))
-        XCTAssertNil(PlacemarkTextFilter.displayable("Tokyo", languageCode: "ja"))
+    /// 混在表記は非ラテン扱いにすること（「東京都 港区 1丁目」等）
+    func testMixedTextIsNonLatin() {
+        XCTAssertEqual(PlacemarkTextFilter.script(of: "東京都 Minato"), .nonLatin)
     }
 
-    // MARK: - 英語端末（ここが「ASCII なら落とす」案との違い）
-
-    /// 英語端末では英語の地名を残すこと。
-    /// ロケール非依存に「英字を落とす」ルールにすると、ここが全滅する。
-    func testEnglishDeviceKeepsEnglishText() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "en"))
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo Chiyoda-Ku", languageCode: "en"))
-        XCTAssertEqual(PlacemarkTextFilter.displayable("Kyoto Kita-Ku, Kyoto", languageCode: "en"), "Kyoto Kita-Ku, Kyoto")
+    /// 数字・記号だけは判定材料が無いので nil
+    func testNonLetterTextHasNoScript() {
+        XCTAssertNil(PlacemarkTextFilter.script(of: "1-2-3"))
+        XCTAssertNil(PlacemarkTextFilter.script(of: ""))
     }
 
-    /// 英語端末に日本語データが返ってきたら落とすこと（混在は逆向きにも起きる）
-    func testEnglishDeviceDropsJapaneseText() {
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("東京都 台東区", languageCode: "en"))
-        XCTAssertNil(PlacemarkTextFilter.displayable("島根県 出雲市", languageCode: "en"))
+    // MARK: - 多数派の判定
+
+    /// 国内: 日本語が多数派なので日本語が基準になる
+    func testDominantScriptInJapan() {
+        let texts = ["東京都", "東京都", "東京都", "東京都", "東京都", "Tokyo"]
+
+        XCTAssertEqual(PlacemarkTextFilter.dominantScript(in: texts), .nonLatin)
     }
 
-    // MARK: - その他の配信対象言語
+    /// 海外: ラテン文字が多数派なのでラテン文字が基準になる
+    func testDominantScriptAbroad() {
+        let texts = ["Île-de-France", "Île-de-France", "Paris", "Paris"]
 
-    /// スペイン語・フランス語はラテン文字なので英語表記を許容すること
-    func testLatinScriptLanguagesAcceptLatinText() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "es"))
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "fr"))
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("東京都", languageCode: "fr"))
+        XCTAssertEqual(PlacemarkTextFilter.dominantScript(in: texts), .latin)
     }
 
-    /// アクセント付き文字をラテン文字として扱うこと（Málaga などを落とさない）
-    func testAccentedLatinIsTreatedAsLatin() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Málaga", languageCode: "es"))
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Île-de-France", languageCode: "fr"))
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Île-de-France", languageCode: "ja"))
+    /// 同数のときは基準を決めない（落とす根拠が無い）
+    func testTieHasNoDominantScript() {
+        XCTAssertNil(PlacemarkTextFilter.dominantScript(in: ["東京都", "Tokyo"]))
     }
 
-    /// 韓国語はラテン文字以外を期待すること
-    func testKoreanExpectsNonLatin() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("서울특별시", languageCode: "ko"))
-        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Seoul", languageCode: "ko"))
+    /// 判定材料が無いときも基準を決めない
+    func testNoDominantScriptWhenNoLetters() {
+        XCTAssertNil(PlacemarkTextFilter.dominantScript(in: []))
+        XCTAssertNil(PlacemarkTextFilter.dominantScript(in: ["123", "456"]))
     }
 
-    // MARK: - 判定材料が無いケース
+    // MARK: - 表示可否
 
-    /// 数字・記号だけのテキストは判定できないので落とさないこと
-    func testNonLetterTextIsKept() {
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("1-2-3", languageCode: "ja"))
-        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("100", languageCode: "en"))
+    /// 国内: 多数派の日本語は残り、浮いた英語だけ落ちる（#29 の報告事象）
+    func testDropsOutlierInJapaneseList() {
+        let dominant = PlacemarkTextFilter.dominantScript(in: ["東京都", "東京都", "Tokyo"])
+
+        XCTAssertTrue(PlacemarkTextFilter.isDisplayable("東京都", dominant: dominant))
+        XCTAssertFalse(PlacemarkTextFilter.isDisplayable("Tokyo", dominant: dominant))
     }
 
-    /// 空・nil は表示対象にしないこと
-    func testEmptyIsNotDisplayable() {
-        XCTAssertNil(PlacemarkTextFilter.displayable(nil, languageCode: "ja"))
-        XCTAssertNil(PlacemarkTextFilter.displayable("", languageCode: "ja"))
+    /// 海外: 全件ラテン文字なら何も落とさない。
+    /// ここが端末言語での絶対判定との決定的な違いで、絶対判定だとパリで全滅していた。
+    func testKeepsEverythingAbroad() {
+        let texts = ["Île-de-France", "Paris", "Île-de-France", "Paris", "Paris", "Île-de-France"]
+        let dominant = PlacemarkTextFilter.dominantScript(in: texts)
+
+        for text in texts {
+            XCTAssertTrue(
+                PlacemarkTextFilter.isDisplayable(text, dominant: dominant),
+                "海外で地域名が落ちている: \(text)"
+            )
+        }
+    }
+
+    /// 海外で1件だけ日本語データがある場合は、そちらが浮くので落ちる
+    func testDropsJapaneseOutlierAbroad() {
+        let dominant = PlacemarkTextFilter.dominantScript(in: ["Paris", "Paris", "パリ"])
+
+        XCTAssertTrue(PlacemarkTextFilter.isDisplayable("Paris", dominant: dominant))
+        XCTAssertFalse(PlacemarkTextFilter.isDisplayable("パリ", dominant: dominant))
+    }
+
+    /// 基準が決まらないときは落とさない（情報を減らすだけになるため）
+    func testKeepsAllWhenNoDominant() {
+        XCTAssertTrue(PlacemarkTextFilter.isDisplayable("東京都", dominant: nil))
+        XCTAssertTrue(PlacemarkTextFilter.isDisplayable("Tokyo", dominant: nil))
+    }
+
+    /// 判定材料が無いテキストは基準があっても落とさない
+    func testKeepsNonLetterText() {
+        XCTAssertTrue(PlacemarkTextFilter.isDisplayable("1-2-3", dominant: .nonLatin))
     }
 }

--- a/SerendipityPlannerTests/PlacemarkTextFilterTests.swift
+++ b/SerendipityPlannerTests/PlacemarkTextFilterTests.swift
@@ -1,0 +1,74 @@
+@testable import SerendipityPlanner
+import XCTest
+
+/// #29: Apple のジオデータ欠損で subtitle の表記が混ざる問題のフォールバック。
+final class PlacemarkTextFilterTests: XCTestCase {
+    // MARK: - 日本語端末
+
+    /// 日本語端末では日本語の地名をそのまま出すこと
+    func testJapaneseDeviceKeepsJapaneseText() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("東京都", languageCode: "ja"))
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("東京都 港区", languageCode: "ja"))
+        XCTAssertEqual(PlacemarkTextFilter.displayable("島根県", languageCode: "ja"), "島根県")
+    }
+
+    /// 日本語端末に英語データが返ってきたら落とすこと（#29 の報告事象）
+    func testJapaneseDeviceDropsEnglishText() {
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "ja"))
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo Chiyoda-Ku", languageCode: "ja"))
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Kyoto Kita-Ku, Kyoto", languageCode: "ja"))
+        XCTAssertNil(PlacemarkTextFilter.displayable("Tokyo", languageCode: "ja"))
+    }
+
+    // MARK: - 英語端末（ここが「ASCII なら落とす」案との違い）
+
+    /// 英語端末では英語の地名を残すこと。
+    /// ロケール非依存に「英字を落とす」ルールにすると、ここが全滅する。
+    func testEnglishDeviceKeepsEnglishText() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "en"))
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo Chiyoda-Ku", languageCode: "en"))
+        XCTAssertEqual(PlacemarkTextFilter.displayable("Kyoto Kita-Ku, Kyoto", languageCode: "en"), "Kyoto Kita-Ku, Kyoto")
+    }
+
+    /// 英語端末に日本語データが返ってきたら落とすこと（混在は逆向きにも起きる）
+    func testEnglishDeviceDropsJapaneseText() {
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("東京都 台東区", languageCode: "en"))
+        XCTAssertNil(PlacemarkTextFilter.displayable("島根県 出雲市", languageCode: "en"))
+    }
+
+    // MARK: - その他の配信対象言語
+
+    /// スペイン語・フランス語はラテン文字なので英語表記を許容すること
+    func testLatinScriptLanguagesAcceptLatinText() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "es"))
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Tokyo", languageCode: "fr"))
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("東京都", languageCode: "fr"))
+    }
+
+    /// アクセント付き文字をラテン文字として扱うこと（Málaga などを落とさない）
+    func testAccentedLatinIsTreatedAsLatin() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Málaga", languageCode: "es"))
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("Île-de-France", languageCode: "fr"))
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Île-de-France", languageCode: "ja"))
+    }
+
+    /// 韓国語はラテン文字以外を期待すること
+    func testKoreanExpectsNonLatin() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("서울특별시", languageCode: "ko"))
+        XCTAssertFalse(PlacemarkTextFilter.matchesDeviceLanguage("Seoul", languageCode: "ko"))
+    }
+
+    // MARK: - 判定材料が無いケース
+
+    /// 数字・記号だけのテキストは判定できないので落とさないこと
+    func testNonLetterTextIsKept() {
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("1-2-3", languageCode: "ja"))
+        XCTAssertTrue(PlacemarkTextFilter.matchesDeviceLanguage("100", languageCode: "en"))
+    }
+
+    /// 空・nil は表示対象にしないこと
+    func testEmptyIsNotDisplayable() {
+        XCTAssertNil(PlacemarkTextFilter.displayable(nil, languageCode: "ja"))
+        XCTAssertNil(PlacemarkTextFilter.displayable("", languageCode: "ja"))
+    }
+}


### PR DESCRIPTION
## 概要

Closes #29

> ⚠️ **数珠繋ぎブランチの最後です。** base は `feature/issue-32-string-catalog`（PR #43）。**#41 → #42 → #43 → 本PR の順にマージしてください。**

Apple のジオデータの言語欠損で、おすすめエリアの subtitle に1件だけ表記の違うものが混ざる問題を表示側で吸収する。

## 事象

丸の内でおすすめエリア6件のうち、皇居外苑だけが英語になっていた。

```
和田倉噴水公園 / 東京都・現在地から約612 m
将門塚       / 東京都・現在地から約783 m
...
皇居外苑     / Tokyo・現在地から約854 m   ← 1件だけ浮く
```

## 判定基準は「端末の言語」ではなく「一覧の多数派」

MapKit が端末の言語設定に従って地名を返すのは正しい挙動で、**日本語設定のまま海外へ行けばラテン文字の地名が返るのが期待どおり**（Apple マップと同じ）。問題はそこではなく **Apple 側のデータ欠損**で、国内では ja データが揃っているのに一部の記録だけ欠けて浮く、という点。

したがって採用してはいけない判定が2つある。

| 案 | なぜ不可か |
|---|---|
| ASCII が含まれていたら落とす（ロケール非依存） | 英語端末で正しく英語が返っているケースまで全滅する |
| 端末の言語と表記体系が違ったら落とす（絶対判定） | **パリで地域名が6件すべて消えた**（ja データがほぼ無いため全件ラテン文字になる）。海外でラテン文字が出るのは正常 |

そこで **その一覧の多数派の表記体系**を基準にし、そこから外れた行だけ落とす**相対判定**にした。

- 東京: 多数派が日本語 → `Tokyo` の1件だけ落ちる
- パリ: 多数派がラテン文字 → 全件そのまま残る

多数派が決まらない（同数・判定材料なし）ときは何も落とさない。基準が無い状態で落とすと情報を減らすだけになるため。

## 実装

subtitle の組み立てには一覧全体の情報が必要なので、1件ずつ確定させる形をやめ、`RecommendationCandidate` として素材（名前・地名テキスト・座標・距離）だけ保持し、**最後にまとめて組み立てる**構造に変えた。多数派は「実際に表示する件数」で判定する（距離で打ち切られた分に引きずられないため）。

新ファイル: `Utilities/PlacemarkTextFilter.swift`

## 動作確認（実 MapKit 通信）

**東京駅** — 浮いた1件だけ落ちる:

```
和田倉噴水公園 / 東京都・現在地から約612 m
将門塚        / 東京都・現在地から約783 m
常盤公園      / 東京都・現在地から約808 m
大手門        / 東京都・現在地から約823 m
桔梗門        / 東京都・現在地から約847 m
皇居外苑      / 現在地から約855 m          ← ここだけ距離のみ
```

**パリ** — 全件残る:

```
Jardin des Combattants de la Nueve / Île-de-France・現在地から約93 m
Rue de Rivoli                      / Île-de-France・現在地から約115 m
Jardin mémoriel en hommage aux...  / Île-de-France・現在地から約145 m
L'Orme de Saint Gervais            / Île-de-France・現在地から約161 m
Square Federico-García-Lorca       / Île-de-France・現在地から約189 m
サン ジャックの塔                    / Île-de-France・現在地から約280 m
```

目的地検索シートを実際に開いて画面表示も確認済み（東京）。

### ユニットテスト

206件パス（+12件）。特に **「海外では何も落とさない」** のテストが、不採用にした絶対判定との違いを固定している。

## 補足

「約612 m」のように数値と単位の間に空白が入るのは #33 で `MeasurementFormatter` に移行したため。CLDR に沿った表記なのでそのままにしている。

検索結果側（目的地検索）は #30 の `MKLocalSearchCompleter` 移行で既に解消済みのため、本PRのスコープは「この近くのおすすめ」のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
